### PR TITLE
BLS Anonymous FTP Service Discont'd March 1 2014

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -98,7 +98,7 @@
       }
     },
     {
-      "url": "ftp://ftp.bls.gov/pub/special.requests/lf/aa2010/aat1.txt",
+      "url": "http://www.bls.gov/cps/aa2010/aat1.txt",
       "name": "aat1_src",
       "title": "Source file from BLS (human readable plain text)",
       "format": "text",


### PR DESCRIPTION
First, I received an "invalid protocol" error from dpm.  Looking deeper, I saw there was no file at the original location anyway.  Replaced with http: src as suggested here: http://www.bls.gov/bls/discontinuation_ftp.htm